### PR TITLE
Arreglo en solapamiento del menu tope para notch en iphones con notch

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,7 +4,7 @@ import {
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import React from "react";
-import { StatusBar, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import {
   Provider as PaperProvider,
   DefaultTheme as PaperDefaultTheme,
@@ -12,6 +12,7 @@ import {
 import { DrawerNavigation } from "./src/components/navigation";
 import { names } from "./src/screens";
 import { ForgotPassword, Launch, Login, Register } from "./src/screens/login";
+import Constants from "expo-constants";
 
 const Stack = createNativeStackNavigator();
 
@@ -44,7 +45,7 @@ const App = () => {
 
 const styles = StyleSheet.create({
   container: {
-    marginTop: StatusBar.currentHeight,
+    marginTop: Constants.statusBarHeight,
     flex: 1,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^6.0.6",
         "@react-navigation/native-stack": "^6.2.5",
         "expo": "~43.0.0",
+        "expo-constants": "~12.1.3",
         "expo-status-bar": "~1.1.0",
         "react": "17.0.1",
         "react-dom": "17.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-native-paper": "^4.10.0",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.8.0",
-    "react-native-web": "0.17.1"
+    "react-native-web": "0.17.1",
+    "expo-constants": "~12.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"


### PR DESCRIPTION
Saludos, se arreglo el solapamiento que hacía en el menu tope con la barra del IOS con notch.
![image](https://user-images.githubusercontent.com/61009556/140751766-1a7113de-08bc-4c39-a853-3c278e1d1f6d.png)
